### PR TITLE
Fix race condition errors reported by go test -race. Merge to develop

### DIFF
--- a/drain/logging_splunk.go
+++ b/drain/logging_splunk.go
@@ -15,8 +15,7 @@ type LoggingSplunk struct {
 	logger      lager.Logger
 	client      splunk.SplunkClient
 	flushWindow time.Duration
-
-	batch []map[string]interface{}
+	events      chan map[string]interface{}
 }
 
 func NewLoggingSplunk(logger lager.Logger, splunkClient splunk.SplunkClient, flushWindow time.Duration) *LoggingSplunk {
@@ -24,6 +23,8 @@ func NewLoggingSplunk(logger lager.Logger, splunkClient splunk.SplunkClient, flu
 		logger:      logger,
 		client:      splunkClient,
 		flushWindow: flushWindow,
+		// FIXME, make buffer size 100 configurable
+		events: make(chan map[string]interface{}, 100),
 	}
 }
 
@@ -34,24 +35,47 @@ func (l *LoggingSplunk) Connect() bool {
 }
 
 func (l *LoggingSplunk) ShipEvents(fields map[string]interface{}, msg string) {
-	l.batch = append(l.batch, l.buildEvent(fields, msg))
+	event := l.buildEvent(fields, msg)
+	l.events <- event
 }
 
 func (l *LoggingSplunk) consume() {
-	ticker := time.Tick(l.flushWindow)
-	for range ticker {
-		if len(l.batch) > 0 {
-			l.logger.Info(fmt.Sprintf("Posting %d events", len(l.batch)))
-			err := l.client.Post(l.batch)
-			if err != nil {
-				l.logger.Fatal("Unable to talk to Splunk", err)
-			}
+	var batch []map[string]interface{}
+	// FIXME, make batchSize configurable
+	batchSize := 50
+	tickChan := time.NewTicker(l.flushWindow).C
 
-			l.batch = make([]map[string]interface{}, 0)
-		} else {
-			l.logger.Debug("No events to post")
+	// Either flush window or batch size reach limits, we flush
+	for {
+		select {
+		case event := <-l.events:
+			batch = append(batch, event)
+			if len(batch) >= batchSize {
+				batch = l.indexEvents(batch)
+			}
+		case <-tickChan:
+			batch = l.indexEvents(batch)
 		}
 	}
+}
+
+// indexEvents indexes events to Splunk
+// return nil when sucessful which clears all outstanding events
+// return what the batch has if there is an error for next retry cycle
+func (l *LoggingSplunk) indexEvents(batch []map[string]interface{}) []map[string]interface{} {
+	if len(batch) == 0 {
+		return batch
+	}
+
+	l.logger.Info(fmt.Sprintf("Posting %d events", len(batch)))
+	err := l.client.Post(batch)
+	if err != nil {
+		l.logger.Error("Unable to talk to Splunk, error=%+v", err)
+		// return back the batch for next retry
+		return batch
+	}
+
+	return nil
 }
 
 func (l *LoggingSplunk) buildEvent(fields map[string]interface{}, msg string) map[string]interface{} {

--- a/drain/logging_splunk_test.go
+++ b/drain/logging_splunk_test.go
@@ -70,7 +70,7 @@ var _ = Describe("LoggingSplunk", func() {
 		logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 		Eventually(func() []map[string]interface{} {
-			return mockClient.CapturedEvents
+			return mockClient.CapturedEvents()
 		}).Should(HaveLen(1))
 	})
 
@@ -82,10 +82,10 @@ var _ = Describe("LoggingSplunk", func() {
 		logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 		Eventually(func() []map[string]interface{} {
-			return mockClient.CapturedEvents
+			return mockClient.CapturedEvents()
 		}).Should(HaveLen(1))
 
-		event = mockClient.CapturedEvents[0]
+		event = mockClient.CapturedEvents()[0]
 
 		data := event["event"].(map[string]interface{})
 		Expect(data).NotTo(HaveKey("index"))
@@ -170,10 +170,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {
@@ -233,10 +233,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {
@@ -292,10 +292,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {
@@ -347,10 +347,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {
@@ -402,10 +402,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {
@@ -468,10 +468,10 @@ var _ = Describe("LoggingSplunk", func() {
 			logging.ShipEvents(loggingMemory.Events[0], loggingMemory.Messages[0])
 
 			Eventually(func() []map[string]interface{} {
-				return mockClient.CapturedEvents
+				return mockClient.CapturedEvents()
 			}).Should(HaveLen(1))
 
-			event = mockClient.CapturedEvents[0]
+			event = mockClient.CapturedEvents()[0]
 		})
 
 		It("metadata", func() {

--- a/sink/splunk_sink_test.go
+++ b/sink/splunk_sink_test.go
@@ -29,12 +29,12 @@ var _ = Describe("LoggingSplunk", func() {
 	It("posts to splunk", func() {
 		message := lager.LogFormat{}
 
-		Expect(mockClient.CapturedEvents).To(BeNil())
+		Expect(mockClient.CapturedEvents()).To(BeNil())
 
 		sink.Log(message)
 		sink.Log(message)
 
-		Expect(mockClient.CapturedEvents).To(HaveLen(2))
+		Expect(mockClient.CapturedEvents()).To(HaveLen(2))
 	})
 
 	It("translates log message metadata to splunk format", func() {
@@ -47,8 +47,8 @@ var _ = Describe("LoggingSplunk", func() {
 
 		sink.Log(message)
 
-		Expect(mockClient.CapturedEvents).To(HaveLen(1))
-		envelope := mockClient.CapturedEvents[0]
+		Expect(mockClient.CapturedEvents()).To(HaveLen(1))
+		envelope := mockClient.CapturedEvents()[0]
 
 		Expect(envelope["time"]).To(Equal("1473180363"))
 
@@ -71,8 +71,8 @@ var _ = Describe("LoggingSplunk", func() {
 
 		sink.Log(message)
 
-		Expect(mockClient.CapturedEvents).To(HaveLen(1))
-		envelope := mockClient.CapturedEvents[0]
+		Expect(mockClient.CapturedEvents()).To(HaveLen(1))
+		envelope := mockClient.CapturedEvents()[0]
 
 		Expect(envelope["time"]).To(Equal("1473180363"))
 
@@ -89,8 +89,8 @@ var _ = Describe("LoggingSplunk", func() {
 
 		sink.Log(message)
 
-		Expect(mockClient.CapturedEvents).To(HaveLen(1))
-		envelope := mockClient.CapturedEvents[0]
+		Expect(mockClient.CapturedEvents()).To(HaveLen(1))
+		envelope := mockClient.CapturedEvents()[0]
 
 		Expect(envelope["sourcetype"]).To(Equal("cf:splunknozzle"))
 		Expect(envelope["host"]).To(Equal("127.0.0.1"))


### PR DESCRIPTION
instead of master.
	modified:   drain/logging_splunk.go
	modified:   drain/logging_splunk_test.go
	modified:   sink/splunk_sink_test.go
	modified:   testing/mocks.go