### PR TITLE
Refactor org/space/app caching

### DIFF
--- a/cache/boltdb.go
+++ b/cache/boltdb.go
@@ -27,9 +27,23 @@ type BoltdbConfig struct {
 	IgnoreMissingApps  bool
 	MissingAppCacheTTL time.Duration
 	AppCacheTTL        time.Duration
+	OrgSpaceCacheTTL   time.Duration
 	AppLimits          int
 
 	Logger lager.Logger
+}
+
+// Org is a CAPI org
+type Org struct {
+	Name        string
+	LastUpdated time.Time
+}
+
+// Space is a CAPI space with a reference to its org's GUID
+type Space struct {
+	Name        string
+	OrgGUID     string
+	LastUpdated time.Time
 }
 
 type Boltdb struct {
@@ -40,6 +54,9 @@ type Boltdb struct {
 	cache       map[string]*App
 	missingApps map[string]struct{}
 
+	orgNameCache   map[string]Org   // caches org guid->org name mapping
+	spaceNameCache map[string]Space // caches space guid->space name mapping
+
 	closing chan struct{}
 	wg      sync.WaitGroup
 	config  *BoltdbConfig
@@ -47,11 +64,13 @@ type Boltdb struct {
 
 func NewBoltdb(client AppClient, config *BoltdbConfig) (*Boltdb, error) {
 	return &Boltdb{
-		appClient:   client,
-		cache:       make(map[string]*App),
-		missingApps: make(map[string]struct{}),
-		closing:     make(chan struct{}),
-		config:      config,
+		appClient:      client,
+		cache:          make(map[string]*App),
+		missingApps:    make(map[string]struct{}),
+		orgNameCache:   make(map[string]Org),
+		spaceNameCache: make(map[string]Space),
+		closing:        make(chan struct{}),
+		config:         config,
 	}, nil
 }
 
@@ -108,7 +127,7 @@ func (c *Boltdb) Close() error {
 	return c.appdb.Close()
 }
 
-// GetAppInfo tries first get app info from cache. If caches doesn't have this
+// GetApp tries first get app info from cache. If caches doesn't have this
 // app info (cache miss), it issues API to retrieve the app info from remote
 // if the app is not already missing and clients don't ignore the missing app
 // info, and then add the app info to the cache
@@ -123,6 +142,7 @@ func (c *Boltdb) GetApp(appGuid string) (*App, error) {
 
 	// Find in cache
 	if app != nil {
+		c.fillOrgAndSpace(app)
 		return app, nil
 	}
 
@@ -208,7 +228,7 @@ func (c *Boltdb) getAllAppsFromRemote() (map[string]*App, error) {
 
 	totalPages := 0
 	q := url.Values{}
-	q.Set("inline-relations-depth", "2")
+	q.Set("inline-relations-depth", "0")
 	if c.config.AppLimits > 0 {
 		// Latest N apps
 		q.Set("order-direction", "desc")
@@ -310,15 +330,68 @@ func (c *Boltdb) fillDatabase(apps map[string]*App) {
 }
 
 func (c *Boltdb) fromPCFApp(app *cfclient.App) *App {
-	return &App{
-		app.Name,
-		app.Guid,
-		app.SpaceData.Entity.Name,
-		app.SpaceData.Entity.Guid,
-		app.SpaceData.Entity.OrgData.Entity.Name,
-		app.SpaceData.Entity.OrgData.Entity.Guid,
-		c.isOptOut(app.Environment),
+	cachedApp := &App{
+		Name:       app.Name,
+		Guid:       app.Guid,
+		SpaceGuid:  app.SpaceGuid,
+		IgnoredApp: c.isOptOut(app.Environment),
 	}
+
+	c.fillOrgAndSpace(cachedApp)
+
+	return cachedApp
+}
+
+func (c *Boltdb) fillOrgAndSpace(app *App) error {
+	now := time.Now()
+
+	c.lock.RLock()
+	space, ok := c.spaceNameCache[app.SpaceGuid]
+	c.lock.RUnlock()
+
+	if !ok || now.Sub(space.LastUpdated) > c.config.OrgSpaceCacheTTL {
+		cfspace, err := c.appClient.GetSpaceByGuid(app.SpaceGuid)
+		if err != nil {
+			return err
+		}
+
+		space = Space{
+			Name:        cfspace.Name,
+			OrgGUID:     cfspace.OrganizationGuid,
+			LastUpdated: now,
+		}
+
+		c.lock.Lock()
+		c.spaceNameCache[app.SpaceGuid] = space
+		c.lock.Unlock()
+	}
+
+	app.SpaceName = space.Name
+	app.OrgGuid = space.OrgGUID
+
+	c.lock.RLock()
+	org, ok := c.orgNameCache[space.OrgGUID]
+	c.lock.RUnlock()
+	if !ok || now.Sub(org.LastUpdated) > c.config.OrgSpaceCacheTTL {
+		cforg, err := c.appClient.GetOrgByGuid(space.OrgGUID)
+		if err != nil {
+			return err
+		}
+
+		org = Org{
+			Name:        cforg.Name,
+			LastUpdated: now,
+		}
+
+		c.lock.Lock()
+		c.orgNameCache[space.OrgGUID] = org
+		c.lock.Unlock()
+	}
+
+	app.OrgGuid = space.OrgGUID
+	app.OrgName = org.Name
+
+	return nil
 }
 
 func (c *Boltdb) getAppFromRemote(appGuid string) (*App, error) {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -28,4 +28,6 @@ type AppClient interface {
 	AppByGuid(appGuid string) (cfclient.App, error)
 	ListApps() ([]cfclient.App, error)
 	ListAppsByQueryWithLimits(query url.Values, totalPages int) ([]cfclient.App, error)
+	GetSpaceByGuid(spaceGUID string) (cfclient.Space, error)
+	GetOrgByGuid(orgGUID string) (cfclient.Org, error)
 }

--- a/eventsink/splunk_test.go
+++ b/eventsink/splunk_test.go
@@ -118,7 +118,6 @@ var _ = Describe("Splunk", func() {
 		var envelopeHttpStartStop *events.HttpStartStop
 		var startTimestamp, stopTimestamp int64
 		var requestId events.UUID
-		var requestIdHex, applicationIdHex string
 		var peerType events.PeerType
 		var method events.Method
 		var uri, remoteAddress, userAgent string
@@ -149,7 +148,6 @@ var _ = Describe("Splunk", func() {
 				Low:  &requestIdLow,
 				High: &requestIdHigh,
 			}
-			requestIdHex = "b12a3f87-83ab-4cf2-554b-042dc36e28f1"
 
 			applicationIdLow := uint64(10539615360601842564)
 			applicationIdHigh := uint64(3160954123591206558)
@@ -157,7 +155,6 @@ var _ = Describe("Splunk", func() {
 				Low:  &applicationIdLow,
 				High: &applicationIdHigh,
 			}
-			applicationIdHex = "8463ec45-543c-4492-9ec6-f52707f7dd2b"
 
 			envelopeHttpStartStop = &events.HttpStartStop{
 				StartTimestamp: &startTimestamp,

--- a/splunknozzle/config.go
+++ b/splunknozzle/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	IgnoreMissingApps  bool          `json:"ignore-missing-apps"`
 	MissingAppCacheTTL time.Duration `json:"missing-app-cache-ttl"`
 	AppCacheTTL        time.Duration `json:"app-cache-ttl"`
+	OrgSpaceCacheTTL   time.Duration `json:"org-space-cache-ttl"`
 	AppLimits          int           `json:"app-limits"`
 
 	BoltDBPath   string `json:"boltdb-path"`
@@ -101,6 +102,8 @@ func NewConfigFromCmdFlags(version, branch, commit, buildos string) *Config {
 		OverrideDefaultFromEnvar("MISSING_APP_CACHE_INVALIDATE_TTL").Default("0s").DurationVar(&c.MissingAppCacheTTL)
 	kingpin.Flag("app-cache-invalidate-ttl", "How frequently the app info local cache invalidates").
 		OverrideDefaultFromEnvar("APP_CACHE_INVALIDATE_TTL").Default("0s").DurationVar(&c.AppCacheTTL)
+	kingpin.Flag("org-space-cache-invalidate-ttl", "How frequently the org and space cache invalidates").
+		OverrideDefaultFromEnvar("ORG_SPACE_CACHE_INVALIDATE_TTL").Default("72h").DurationVar(&c.OrgSpaceCacheTTL)
 	kingpin.Flag("app-limits", "Restrict to APP_LIMITS most updated apps per request when populating the app metadata cache").
 		OverrideDefaultFromEnvar("APP_LIMITS").Default("0").IntVar(&c.AppLimits)
 

--- a/splunknozzle/nozzle.go
+++ b/splunknozzle/nozzle.go
@@ -55,6 +55,7 @@ func (s *SplunkFirehoseNozzle) AppCache(client cache.AppClient, logger lager.Log
 			IgnoreMissingApps:  s.config.IgnoreMissingApps,
 			MissingAppCacheTTL: s.config.MissingAppCacheTTL,
 			AppCacheTTL:        s.config.AppCacheTTL,
+			OrgSpaceCacheTTL:   s.config.OrgSpaceCacheTTL,
 			Logger:             logger,
 		}
 		return cache.NewBoltdb(client, &c)


### PR DESCRIPTION
Currently, `go-cfclient` uses `inline-relations-depth=2`. This is
incredibly inefficient and computationally intensive on the Cloud
Controller database. This commit refactors the caching system to
use `inline-relations-depth=0` and explicitly gets the org and
space for an app to be cached. The TTL for orgs and spaces is
a different value because it can (and should be) much longer than
for apps.

All unit tests currently pass and have added extra tests to ensure
things are working as expected. I did performance testing by creating
a CF environment where I had 1400 apps evenly distributed
(7 apps per space, 8 spaces per org, 25 orgs). Using the new method
of getting orgs and spaces directly resulted in an approximately
25% performance increase, just in terms of speed. This is obviously
dependent on org/space structure, but it is shown to be faster.

Further, inspecting the CPU utilization during the calls indicate that
(at least on the test system I have), using inline-relations-depth=2
to get all apps, orgs, and spaces resulted in ~60% CPU utilization on
an otherwise idle system, while using multiple calls resulted in, on
average, 35% CPU utilization.

Thanks for considering this!