### PR TITLE
Convert from static retry time to exponential backoff

### DIFF
--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -2,15 +2,17 @@ package eventsink
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"sync/atomic"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/eventwriter"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/utils"
-	"sync/atomic"
 )
 
 const SPLUNK_HEC_FIELDS_SUPPORT_VERSION = "6.4"
@@ -124,7 +126,7 @@ func (s *Splunk) indexEvents(writer eventwriter.Writer, batch []map[string]inter
 			return nil
 		}
 		s.config.Logger.Error("Unable to talk to Splunk", err)
-		time.Sleep(5 * time.Second)
+		time.Sleep(getRetryInterval(i))
 	}
 	s.config.Logger.Error("Finish retrying and dropping events", err, lager.Data{"events": len(batch)})
 	return nil
@@ -209,4 +211,10 @@ func (s *Splunk) Log(message lager.LogFormat) {
 
 	events := []map[string]interface{}{event}
 	s.writers[len(s.writers)-1].Write(events)
+}
+
+func getRetryInterval(attempt int) time.Duration {
+	// algorithm taken from https://en.wikipedia.org/wiki/Exponential_backoff
+	timeInSec := 5 + (0.5 * (math.Exp2(float64(attempt)) - 1.0))
+	return time.Millisecond * time.Duration(1000*timeInSec)
 }

--- a/eventsink/splunk_test.go
+++ b/eventsink/splunk_test.go
@@ -118,7 +118,6 @@ var _ = Describe("Splunk", func() {
 		var envelopeHttpStartStop *events.HttpStartStop
 		var startTimestamp, stopTimestamp int64
 		var requestId events.UUID
-		var requestIdHex, applicationIdHex string
 		var peerType events.PeerType
 		var method events.Method
 		var uri, remoteAddress, userAgent string
@@ -149,7 +148,6 @@ var _ = Describe("Splunk", func() {
 				Low:  &requestIdLow,
 				High: &requestIdHigh,
 			}
-			requestIdHex = "b12a3f87-83ab-4cf2-554b-042dc36e28f1"
 
 			applicationIdLow := uint64(10539615360601842564)
 			applicationIdHigh := uint64(3160954123591206558)
@@ -157,7 +155,6 @@ var _ = Describe("Splunk", func() {
 				Low:  &applicationIdLow,
 				High: &applicationIdHigh,
 			}
-			applicationIdHex = "8463ec45-543c-4492-9ec6-f52707f7dd2b"
 
 			envelopeHttpStartStop = &events.HttpStartStop{
 				StartTimestamp: &startTimestamp,


### PR DESCRIPTION
This will increase the time between connection events to allow an HEC
to catch up. For an example on how this will affect time between connect
attempts, try https://play.golang.org/p/GwqQydwnaFd. You can change the
value of `maxRetries` to see what the *n*th retry attempt will look like.

The test changes are simply to have this pass in a Go 1.11 environment.