### PR TITLE
fix info_splunk_index null value issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ workflows:
           filters:
             branches:
               only:
-                - INGEST-15507-nozzle-v2-update
                 - develop
                 - master
       - tile-builder:

--- a/events/events.go
+++ b/events/events.go
@@ -165,7 +165,10 @@ func (e *Event) AnnotateWithAppData(appCache cache.Cache) {
 			e.Fields["cf_org_name"] = cf_org_name
 		}
 
-		e.Fields["info_splunk_index"] = app_env["SPLUNK_INDEX"]
+		if app_env["SPLUNK_INDEX"] != nil {
+			e.Fields["info_splunk_index"] = app_env["SPLUNK_INDEX"]
+		}
+
 		e.Fields["cf_ignored_app"] = cf_ignored_app
 	}
 }


### PR DESCRIPTION
- fix null index issue and populate "info_splunk_index" field only when "SPLUNK_INDEX" is configured in applications to route data to different indexes. 
- Update CI deploy pipeline filter