### PR TITLE
INGEST-17577-added retry counter (i) in the error message

### DIFF
--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -125,7 +125,7 @@ func (s *Splunk) indexEvents(writer eventwriter.Writer, batch []map[string]inter
 		if err == nil {
 			return nil
 		}
-		s.config.Logger.Error("Unable to talk to Splunk", err)
+		s.config.Logger.Error("Unable to talk to Splunk", err, lager.Data{"Retry attempt": i + 1})
 		time.Sleep(getRetryInterval(i))
 	}
 	s.config.Logger.Error("Finish retrying and dropping events", err, lager.Data{"events": len(batch)})


### PR DESCRIPTION
Include the current retry counter (i) in the error message to know how many retries were needed to deliver a batch