### PR TITLE
remove tag fields - not in scope for 2.0 release.

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -184,8 +184,6 @@ func (e *Event) AnnotateWithEnvelopeData(msg *events.Envelope) {
 	e.Fields["ip"] = msg.GetIp()
 	e.Fields["job"] = msg.GetJob()
 	e.Fields["job_index"] = msg.GetIndex()
-	// Adding tags
-	e.Fields["tags"] = msg.GetTags()
 	e.Type = msg.GetEventType().String()
 }
 

--- a/splunknozzle/config.go
+++ b/splunknozzle/config.go
@@ -130,7 +130,7 @@ func NewConfigFromCmdFlags(version, branch, commit, buildos string) *Config {
 		OverrideDefaultFromEnvar("CONSUMER_QUEUE_SIZE").Default("10000").IntVar(&c.QueueSize)
 	kingpin.Flag("hec-batch-size", "Batchsize of the events pushing to HEC").
 		OverrideDefaultFromEnvar("HEC_BATCH_SIZE").Default("100").IntVar(&c.BatchSize)
-	kingpin.Flag("rlp-gateway-retries", "Number of retries to connect to PCF RLP gateway").
+	kingpin.Flag("rlp-gateway-retries", "Number of retries to connect to RLP gateway").
 		OverrideDefaultFromEnvar("RLP_GATEWAY_RETRIES").Default("10").IntVar(&c.RLPGatewayRetries)
 	kingpin.Flag("hec-retries", "Number of retries before dropping events").
 		OverrideDefaultFromEnvar("HEC_RETRIES").Default("5").IntVar(&c.Retries)

--- a/splunknozzle/nozzle.go
+++ b/splunknozzle/nozzle.go
@@ -223,7 +223,7 @@ func (s *SplunkFirehoseNozzle) Run(shutdownChan chan os.Signal) error {
 		noz.Close()
 		return eventSink.Close()
 	case gatewayError := <-gatewayErrChan:
-		s.logger.Error("Error from PCF RLP gateway", gatewayError)
+		s.logger.Error("Error from RLP gateway", gatewayError)
 		noz.Close()
 		eventSink.Close()
 		return gatewayError


### PR DESCRIPTION
Tag fields needs to be revisited in the next release. Not in scope for current release. 
