### PR TITLE
Add telemetry data (appname and appversion) to HEC requests

### DIFF
--- a/eventwriter/splunk.go
+++ b/eventwriter/splunk.go
@@ -85,13 +85,16 @@ func (s *splunkClient) send(postBody *[]byte) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("Authorization", fmt.Sprintf("Splunk %s", s.config.Token))
+	//Add app headers for HEC telemetry
+	//Todo: update static values with appName and appVersion variables
+	req.Header.Set("__splunk_app_name", "Splunk Firehose Nozzle")
+	req.Header.Set("__splunk_app_version", "2.0.0")
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode > 299 {
 		responseBody, _ := ioutil.ReadAll(resp.Body)
 		return errors.New(fmt.Sprintf("Non-ok response code [%d] from splunk: %s", resp.StatusCode, responseBody))

--- a/eventwriter/splunk_test.go
+++ b/eventwriter/splunk_test.go
@@ -88,6 +88,36 @@ var _ = Describe("Splunk", func() {
 			Expect(contentType).To(Equal("application/json"))
 		})
 
+		It("sets app name to appName", func() {
+			appName := "Splunk Firehose Nozzle"
+
+			client := NewSplunk(config)
+			events := []map[string]interface{}{}
+			err, _ := client.Write(events)
+
+			Expect(err).To(BeNil())
+			Expect(capturedRequest).NotTo(BeNil())
+
+			applicationName := capturedRequest.Header.Get("__splunk_app_name")
+			Expect(applicationName).To(Equal(appName))
+
+		})
+
+		It("sets app appVersion", func() {
+			appVersion := "2.0.0"
+
+			client := NewSplunk(config)
+			events := []map[string]interface{}{}
+			err, _ := client.Write(events)
+
+			Expect(err).To(BeNil())
+			Expect(capturedRequest).NotTo(BeNil())
+
+			applicationVersion := capturedRequest.Header.Get("__splunk_app_version")
+			Expect(applicationVersion).To(Equal(appVersion))
+
+		})
+
 		It("Writes batch event json", func() {
 			client := NewSplunk(config)
 			event1 := map[string]interface{}{"event": map[string]interface{}{


### PR DESCRIPTION
Add telemetry data to nozzle hec client. 