### PR TITLE
make add-app-info an optional field

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -101,6 +101,7 @@ forms:
   - name: add_app_info
     type: multi_select_options
     label: Add App Information
+    optional: true
     options:
       - name: AppName
         label: AppName


### PR DESCRIPTION
Updated add-app-info config to be optional in the tile. 