### PR TITLE
Convert NaN or Infinity value metrics to string

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -121,11 +122,21 @@ func LogMessage(msg *events.Envelope) *Event {
 
 func ValueMetric(msg *events.Envelope) *Event {
 	valMetric := msg.GetValueMetric()
+	value := valMetric.GetValue()
 
 	fields := logrus.Fields{
 		"name":  valMetric.GetName(),
 		"unit":  valMetric.GetUnit(),
-		"value": valMetric.GetValue(),
+		"value": value,
+	}
+
+	// Convert special values
+	if math.IsNaN(value) {
+		fields["value"] = "NaN"
+	} else if math.IsInf(value, 1) {
+		fields["value"] = "Infinity"
+	} else if math.IsInf(value, -1) {
+		fields["value"] = "-Infinity"
 	}
 
 	return &Event{

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Events", func() {
 		Expect(evt.Fields["value"]).To(Equal(value))
 		Expect(evt.Fields["unit"]).To(Equal(unit))
 	})
-	
+
 	It("ValueMetric NaN", func() {
 		msg = NewValueMetric()
 		nan := math.NaN()
@@ -116,7 +116,7 @@ var _ = Describe("Events", func() {
 		Expect(evt.Fields["unit"]).To(Equal(unit))
 	})
 
-	It("ValueMetric +Infinity", func() {
+	It("ValueMetric -Infinity", func() {
 		msg = NewValueMetric()
 		inf := math.Inf(-1)
 		msg.ValueMetric.Value = &inf

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,6 +1,8 @@
 package events_test
 
 import (
+	"math"
+
 	fevents "github.com/cloudfoundry-community/splunk-firehose-nozzle/events"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/testing"
 	. "github.com/cloudfoundry/sonde-go/events"
@@ -85,6 +87,45 @@ var _ = Describe("Events", func() {
 		Expect(evt.Msg).To(Equal(""))
 		Expect(evt.Fields["name"]).To(Equal(name))
 		Expect(evt.Fields["value"]).To(Equal(value))
+		Expect(evt.Fields["unit"]).To(Equal(unit))
+	})
+	
+	It("ValueMetric NaN", func() {
+		msg = NewValueMetric()
+		nan := math.NaN()
+		msg.ValueMetric.Value = &nan
+		evt := fevents.ValueMetric(msg)
+		Expect(evt).ToNot(BeNil())
+		Expect(evt.Fields).ToNot(BeNil())
+		Expect(evt.Msg).To(Equal(""))
+		Expect(evt.Fields["name"]).To(Equal(name))
+		Expect(evt.Fields["value"]).To(Equal("NaN"))
+		Expect(evt.Fields["unit"]).To(Equal(unit))
+	})
+
+	It("ValueMetric +Infinity", func() {
+		msg = NewValueMetric()
+		inf := math.Inf(1)
+		msg.ValueMetric.Value = &inf
+		evt := fevents.ValueMetric(msg)
+		Expect(evt).ToNot(BeNil())
+		Expect(evt.Fields).ToNot(BeNil())
+		Expect(evt.Msg).To(Equal(""))
+		Expect(evt.Fields["name"]).To(Equal(name))
+		Expect(evt.Fields["value"]).To(Equal("Infinity"))
+		Expect(evt.Fields["unit"]).To(Equal(unit))
+	})
+
+	It("ValueMetric +Infinity", func() {
+		msg = NewValueMetric()
+		inf := math.Inf(-1)
+		msg.ValueMetric.Value = &inf
+		evt := fevents.ValueMetric(msg)
+		Expect(evt).ToNot(BeNil())
+		Expect(evt.Fields).ToNot(BeNil())
+		Expect(evt.Msg).To(Equal(""))
+		Expect(evt.Fields["name"]).To(Equal(name))
+		Expect(evt.Fields["value"]).To(Equal("-Infinity"))
 		Expect(evt.Fields["unit"]).To(Equal(unit))
 	})
 


### PR DESCRIPTION
The Loggregator ValueMetric evenlopes include double values like NaN or Infinity which require special handling when serializing them.

Currently, the encoder errors out when these special values are sent since they are not included in the JSON spec. This PR attempts to resolve that by converting them to strings NaN, Infinity, -Infinity.