### PR TITLE
Bugfix/disconnect due to slow consumer event drop

### DIFF
--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -88,7 +88,7 @@ func (s *Splunk) Write(fields map[string]interface{}, msg string) error {
 		s.DroppedEvents += 1
 		if int(s.DroppedEvents)%s.config.DropWarnThreshold == 0 {
 			s.config.Logger.Error("Downstream is slow, dropped Total of "+strconv.FormatUint(s.DroppedEvents, 10)+" events",
-				errors.New("dropped more than "+strconv.FormatUint(uint64(s.config.DropWarnThreshold), 10)+" events"))
+				errors.New("dropped more "+strconv.FormatUint(uint64(s.config.DropWarnThreshold), 10)+" events, Total of "+strconv.FormatUint(s.DroppedEvents, 10)+" dropped events"))
 		}
 	}
 	return nil

--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -85,9 +85,9 @@ func (s *Splunk) Write(fields map[string]interface{}, msg string) error {
 	case s.events <- fields:
 	default:
 		s.DroppedEvents += 1
+		s.config.Logger.Debug("Dropping an event due to slow downstream")
 		if s.DroppedEvents%1000 == 0 {
-			// s.config.Logger.Warning("Downstream is slow, dropping 1000 events")
-			s.config.Logger.Error("Downstream is slow, dropping 1000 events", errors.New("Dropped Total of "+strconv.FormatUint(s.DroppedEvents, 10)+" events"))
+			s.config.Logger.Error("Downstream is slow, dropped Total of "+strconv.FormatUint(s.DroppedEvents, 10)+" events", errors.New("dropped more than 1000 events"))
 		}
 	}
 	return nil

--- a/eventsink/splunk_test.go
+++ b/eventsink/splunk_test.go
@@ -116,8 +116,6 @@ var _ = Describe("Splunk", func() {
 		sink.Open()
 		sink.Write(memSink.Events[0], memSink.Messages[0])
 		sink.Write(memSink.Events[1], memSink.Messages[1])
-		mockClient.Block = false
-		mockClient2.Block = false
 
 		Eventually(func() []map[string]interface{} {
 			return mockClient.CapturedEvents()

--- a/eventsink/splunk_test.go
+++ b/eventsink/splunk_test.go
@@ -96,15 +96,16 @@ var _ = Describe("Splunk", func() {
 
 	It("does not block when downstream is blocked", func() {
 		config := &eventsink.SplunkConfig{
-			FlushInterval: time.Millisecond,
-			QueueSize:     1,
-			BatchSize:     1,
-			Retries:       1,
-			Hostname:      "localhost",
-			Version:       "6.6",
-			ExtraFields:   map[string]string{"env": "dev", "test": "field"},
-			UUID:          "0a956421-f2e1-4215-9d88-d15633bb3023",
-			Logger:        logger,
+			FlushInterval:     time.Millisecond,
+			QueueSize:         1,
+			BatchSize:         1,
+			Retries:           1,
+			Hostname:          "localhost",
+			Version:           "6.6",
+			ExtraFields:       map[string]string{"env": "dev", "test": "field"},
+			UUID:              "0a956421-f2e1-4215-9d88-d15633bb3023",
+			Logger:            logger,
+			DropWarnThreshold: 10,
 		}
 		sink = eventsink.NewSplunk([]eventwriter.Writer{mockClient, mockClient2}, config)
 		eventType = events.Envelope_Error

--- a/splunknozzle/config.go
+++ b/splunknozzle/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	TraceLogging          bool          `json:"trace-logging"`
 	Debug                 bool          `json:"debug"`
 	StatusMonitorInterval time.Duration `json:"mem-queue-monitor-interval"`
+	DropWarnThreshold     int           `json:"drop-warn-threshold"`
 }
 
 func NewConfigFromCmdFlags(version, branch, commit, buildos string) *Config {
@@ -143,6 +144,8 @@ func NewConfigFromCmdFlags(version, branch, commit, buildos string) *Config {
 		OverrideDefaultFromEnvar("DEBUG").Default("false").BoolVar(&c.Debug)
 	kingpin.Flag("status-monitor-interval", "Print information for monitoring at every interval").
 		OverrideDefaultFromEnvar("STATUS_MONITOR_INTERVAL").Default("0s").DurationVar(&c.StatusMonitorInterval)
+	kingpin.Flag("drop-warn-threshold", "Log error with dropped events count at each threshold count due to slow downstream").
+		OverrideDefaultFromEnvar("DROP_WARN_THRESHOLD").Default("1000").IntVar(&c.DropWarnThreshold)
 
 	kingpin.Parse()
 	return c

--- a/splunknozzle/config_test.go
+++ b/splunknozzle/config_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Config", func() {
 
 			os.Setenv("ENABLE_EVENT_TRACING", "true")
 			os.Setenv("DEBUG", "true")
+			os.Setenv("DROP_WARN_THRESHOLD", "100")
 
 			c := NewConfigFromCmdFlags(version, branch, commit, buildos)
 
@@ -114,6 +115,7 @@ var _ = Describe("Config", func() {
 
 			Expect(c.TraceLogging).To(BeTrue())
 			Expect(c.Debug).To(BeTrue())
+			Expect(c.DropWarnThreshold).To(Equal(100))
 		})
 
 		It("check defaults", func() {
@@ -148,6 +150,7 @@ var _ = Describe("Config", func() {
 
 			Expect(c.TraceLogging).To(BeFalse())
 			Expect(c.Debug).To(BeFalse())
+			Expect(c.DropWarnThreshold).To(Equal(1000))
 		})
 	})
 
@@ -196,6 +199,7 @@ var _ = Describe("Config", func() {
 				"--splunk-version=5.2",
 				"--enable-event-tracing",
 				"--debug",
+				"--drop-warn-threshold=10",
 			}
 			os.Args = args
 		})
@@ -242,6 +246,7 @@ var _ = Describe("Config", func() {
 
 			Expect(c.Debug).To(BeTrue())
 			Expect(c.TraceLogging).To(BeTrue())
+			Expect(c.DropWarnThreshold).To(Equal(10))
 
 			Expect(c.Version).To(Equal(version))
 			Expect(c.Branch).To(Equal(branch))

--- a/splunknozzle/nozzle.go
+++ b/splunknozzle/nozzle.go
@@ -119,6 +119,7 @@ func (s *SplunkFirehoseNozzle) EventSink() (eventsink.Sink, error) {
 		UUID:                  nozzleUUID,
 		Logger:                s.logger,
 		StatusMonitorInterval: s.config.StatusMonitorInterval,
+		DropWarnThreshold:     s.config.DropWarnThreshold,
 	}
 
 	splunkSink := eventsink.NewSplunk(writers, sinkConfig)

--- a/testing/event_writer_mock.go
+++ b/testing/event_writer_mock.go
@@ -15,7 +15,7 @@ type EventWriterMock struct {
 }
 
 func (m *EventWriterMock) Write(events []map[string]interface{}) (error, uint64) {
-	for m.Block {
+	if m.Block {
 		time.Sleep(time.Millisecond * 100)
 	}
 	if m.ReturnErr {

--- a/testing/event_writer_mock.go
+++ b/testing/event_writer_mock.go
@@ -3,16 +3,21 @@ package testing
 import (
 	"errors"
 	"sync"
+	"time"
 )
 
 type EventWriterMock struct {
 	lock           sync.Mutex
+	Block          bool
 	capturedEvents []map[string]interface{}
 	PostBatchFn    func(events []map[string]interface{}) error
 	ReturnErr      bool
 }
 
 func (m *EventWriterMock) Write(events []map[string]interface{}) (error, uint64) {
+	for m.Block {
+		time.Sleep(time.Millisecond * 100)
+	}
 	if m.ReturnErr {
 		return errors.New("mockup error"), 0
 	}


### PR DESCRIPTION
Adding mechanism to drop events if the events queue is full to avoid the blocking of the main nozzle goroutine and hence avoid passing the back pressure back to Doppler when the downstream is slow.

There is still room to further improve it by moving the event parsing from main thread to writer threads. This will be addressed in later pull-requests targeted in subsequent releases.