### PR TITLE
Updated cache.GetApp logic to retrieve app info from boltdb database as well

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Cache", func() {
 			// recorded the missing app, so nil, err is expected to return
 			app, err = cache.GetApp(guid)
 			Ω(err).Should(HaveOccurred())
-			Expect(err).To(Equal(MissingAndIgnoredErr))
+			Expect(err).To(Equal(ErrMissingAndIgnored))
 			Expect(app).To(Equal(nilApp))
 
 			time.Sleep(missingAppCacheTTL + 3)
@@ -99,7 +99,7 @@ var _ = Describe("Cache", func() {
 			// will be returned instead of MissingAndIgnoredErr
 			app, err = cache.GetApp(guid)
 			Ω(err).Should(HaveOccurred())
-			Expect(err).NotTo(Equal(MissingAndIgnoredErr))
+			Expect(err).NotTo(Equal(ErrMissingAndIgnored))
 			Expect(app).To(Equal(nilApp))
 		})
 	})

--- a/events/events.go
+++ b/events/events.go
@@ -201,7 +201,11 @@ func (e *Event) AnnotateWithAppData(appCache cache.Cache, config *Config) {
 	if cf_app_id != nil && appGuid != "<nil>" && cf_app_id != "" {
 		appInfo, err := appCache.GetApp(appGuid)
 		if err != nil {
-			logrus.Error("Failed to fetch application metadata: ", err)
+			if err == cache.ErrMissingAndIgnored {
+				logrus.Info(err.Error(), cf_app_id)
+			} else {
+				logrus.Error("Failed to fetch application metadata from remote: ", err)
+			}
 			return
 		} else if appInfo == nil {
 			return


### PR DESCRIPTION
Did following changes:

- Changed the logic of cache.GetApp to retrieve app info from boltdb database if we do not  find it from in-memory cache or remote.
- Updated code comments accordingly
- Added new debug logs to track when cache invalidation is done
- Fixed gostaticcheck warning in some error messages