### PR TITLE
drained the response buffer to reuse the connection with HEC

### DIFF
--- a/eventwriter/splunk.go
+++ b/eventwriter/splunk.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -98,6 +99,9 @@ func (s *splunkClient) send(postBody *[]byte) error {
 	if resp.StatusCode > 299 {
 		responseBody, _ := ioutil.ReadAll(resp.Body)
 		return errors.New(fmt.Sprintf("Non-ok response code [%d] from splunk: %s", resp.StatusCode, responseBody))
+	} else {
+		//Draining the response buffer, so that the same connection can be reused the next time
+		io.Copy(ioutil.Discard, resp.Body)
 	}
 
 	return nil


### PR DESCRIPTION
The HEC connections were not getting reused, and a new connection was getting created at every request. This created issues with the load-balancer in cloud deployment.

The connection logic was already implemented in a way to reuse the connection but the buffer was not drained for the successful requests, which prevented the connections to be reused. Fixed the issue.