### PR TITLE
Bugfix/disconnect due to slow consumer

### DIFF
--- a/eventrouter/default.go
+++ b/eventrouter/default.go
@@ -1,8 +1,6 @@
 package eventrouter
 
 import (
-	// "fmt"
-
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/cache"
 	fevents "github.com/cloudfoundry-community/splunk-firehose-nozzle/events"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/eventsink"
@@ -34,13 +32,6 @@ func New(appCache cache.Cache, sink eventsink.Sink, config *Config) (Router, err
 }
 
 func (r *router) Route(msg *events.Envelope) error {
-
-	// err := r.sink.Write(event.Fields, event.Msg)
-	// if err != nil {
-	// 	fields := map[string]interface{}{"err": fmt.Sprintf("%s", err)}
-	// 	r.sink.Write(fields, "Failed to write events")
-	// }
-
 	_ = r.sink.Write(msg)
 
 	return nil

--- a/eventrouter/eventrouter_test.go
+++ b/eventrouter/eventrouter_test.go
@@ -76,22 +76,7 @@ var _ = Describe("eventrouter", func() {
 			err := r.Route(msg)
 			Ω(err).ShouldNot(HaveOccurred())
 			Expect(len(memSink.Events)).To(Equal(i + 1))
-			Expect(len(memSink.Messages)).To(Equal(i + 1))
 		}
-	})
-
-	It("Route un-selected message", func() {
-		config := &Config{
-			SelectedEvents: "HttpStart",
-		}
-		r, err = New(noCache, memSink, config)
-		Ω(err).ShouldNot(HaveOccurred())
-
-		eventType = events.Envelope_HttpStop
-		err := r.Route(msg)
-		Ω(err).ShouldNot(HaveOccurred())
-		Expect(len(memSink.Events)).To(Equal(0))
-		Expect(len(memSink.Messages)).To(Equal(0))
 	})
 
 	It("Route default selected message", func() {
@@ -105,55 +90,6 @@ var _ = Describe("eventrouter", func() {
 		err := r.Route(msg)
 		Ω(err).ShouldNot(HaveOccurred())
 		Expect(len(memSink.Events)).To(Equal(1))
-		Expect(len(memSink.Messages)).To(Equal(1))
-	})
-
-	It("Route invalid message, no error", func() {
-		eventType = events.Envelope_EventType(1000)
-		err := r.Route(msg)
-		// Since we will error out first
-		Ω(err).ShouldNot(HaveOccurred())
-		Expect(len(memSink.Events)).To(Equal(0))
-		Expect(len(memSink.Messages)).To(Equal(0))
-	})
-
-	It("Route invalid message, error out", func() {
-		invalid := events.Envelope_EventType(-1)
-
-		// Update the map
-		events.Envelope_EventType_value["invalid"] = int32(invalid)
-		events.Envelope_EventType_name[int32(invalid)] = "invalid"
-
-		config := &Config{
-			SelectedEvents: "invalid",
-		}
-		r, err = New(noCache, memSink, config)
-		Ω(err).ShouldNot(HaveOccurred())
-
-		eventType = invalid
-		err := r.Route(msg)
-
-		Ω(err).Should(HaveOccurred())
-		Expect(len(memSink.Events)).To(Equal(0))
-		Expect(len(memSink.Messages)).To(Equal(0))
-	})
-
-	It("Route ignore app", func() {
-		noCache.SetIgnoreApp(true)
-		eventType = events.Envelope_LogMessage
-		err := r.Route(msg)
-		Ω(err).ShouldNot(HaveOccurred())
-		Expect(len(memSink.Events)).To(Equal(0))
-		Expect(len(memSink.Messages)).To(Equal(0))
-	})
-
-	It("Route sink error", func() {
-		memSink.ReturnErr = true
-		eventType = events.Envelope_LogMessage
-		err := r.Route(msg)
-		Ω(err).Should(HaveOccurred())
-		Expect(len(memSink.Events)).To(Equal(0))
-		Expect(len(memSink.Messages)).To(Equal(0))
 	})
 
 	It("Invalid event", func() {

--- a/eventsink/sink.go
+++ b/eventsink/sink.go
@@ -1,7 +1,9 @@
 package eventsink
 
+import "github.com/cloudfoundry/sonde-go/events"
+
 type Sink interface {
 	Open() error
 	Close() error
-	Write(fields map[string]interface{}, msg string) error
+	Write(fields *events.Envelope) error
 }

--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -12,8 +12,11 @@ import (
 	"sync/atomic"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/cloudfoundry-community/splunk-firehose-nozzle/cache"
+	fevents "github.com/cloudfoundry-community/splunk-firehose-nozzle/events"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/eventwriter"
 	"github.com/cloudfoundry-community/splunk-firehose-nozzle/utils"
+	"github.com/cloudfoundry/sonde-go/events"
 )
 
 const SPLUNK_HEC_FIELDS_SUPPORT_VERSION = "6.4"
@@ -33,10 +36,14 @@ type SplunkConfig struct {
 	DropWarnThreshold     int
 }
 
+type ParseConfig = fevents.Config
+
 type Splunk struct {
 	writers       []eventwriter.Writer
 	config        *SplunkConfig
-	events        chan map[string]interface{}
+	parseConfig   *ParseConfig
+	appCache      cache.Cache
+	events        chan *events.Envelope
 	wg            sync.WaitGroup
 	eventCount    uint64
 	sentCountChan chan uint64
@@ -46,14 +53,16 @@ type Splunk struct {
 	ip string
 }
 
-func NewSplunk(writers []eventwriter.Writer, config *SplunkConfig) *Splunk {
+func NewSplunk(writers []eventwriter.Writer, config *SplunkConfig, parseConfig *ParseConfig, appCache cache.Cache) *Splunk {
 	hostname, ip, _ := utils.GetHostIPInfo(config.Hostname)
 	config.Hostname = hostname
 
 	return &Splunk{
 		writers:       writers,
 		config:        config,
-		events:        make(chan map[string]interface{}, config.QueueSize),
+		parseConfig:   parseConfig,
+		appCache:      appCache,
+		events:        make(chan *events.Envelope, config.QueueSize),
 		ip:            ip,
 		eventCount:    0,
 		sentCountChan: make(chan uint64, 100),
@@ -76,10 +85,59 @@ func (s *Splunk) Close() error {
 	return nil
 }
 
-func (s *Splunk) Write(fields map[string]interface{}, msg string) error {
-	if len(msg) > 0 {
-		fields["msg"] = msg
+func (s *Splunk) parseEvent(msg *events.Envelope) (map[string]interface{}, string) {
+	eventType := msg.GetEventType()
+
+	// if _, ok := r.selectedEvents[eventType.String()]; !ok {
+	// 	// Ignore this event since we are not interested
+	// 	return nil
+	// }
+
+	var event *fevents.Event
+	switch eventType {
+	case events.Envelope_HttpStartStop:
+		event = fevents.HttpStartStop(msg)
+	case events.Envelope_LogMessage:
+		event = fevents.LogMessage(msg)
+	case events.Envelope_ValueMetric:
+		event = fevents.ValueMetric(msg)
+	case events.Envelope_CounterEvent:
+		event = fevents.CounterEvent(msg)
+	case events.Envelope_Error:
+		event = fevents.ErrorEvent(msg)
+	case events.Envelope_ContainerMetric:
+		event = fevents.ContainerMetric(msg)
+	case events.Envelope_HttpStart:
+		event = fevents.HttpStart(msg)
+	case events.Envelope_HttpStop:
+		event = fevents.HttpStop(msg)
+
+	default:
+		// return fmt.Errorf("unsupported event type: %s", eventType.String())
+		return nil, ""
 	}
+
+	event.AnnotateWithEnvelopeData(msg, s.parseConfig)
+	event.AnnotateWithCFMetaData()
+
+	if _, hasAppId := event.Fields["cf_app_id"]; hasAppId {
+		event.AnnotateWithAppData(s.appCache, s.parseConfig)
+	}
+
+	if ignored, ok := event.Fields["cf_ignored_app"]; ok {
+		if ignoreApp, ok := ignored.(bool); ok && ignoreApp {
+			// Ignore events from this app since end user tag to ignore this app
+			return nil, ""
+		}
+	}
+
+	return event.Fields, event.Msg
+}
+
+func (s *Splunk) Write(fields *events.Envelope) error {
+	// if len(msg) > 0 {
+	// 	fields["msg"] = msg
+	// }
 
 	select {
 	case s.events <- fields:
@@ -109,8 +167,10 @@ LOOP:
 				break LOOP
 			}
 
-			event = s.buildEvent(event)
-			batch = append(batch, event)
+			parsedEvent, _ := s.parseEvent(event)
+
+			finalEvent := s.buildEvent(parsedEvent)
+			batch = append(batch, finalEvent)
 			if len(batch) >= s.config.BatchSize {
 				batch = s.indexEvents(writer, batch)
 				timer.Reset(s.config.FlushInterval) // reset channel timer

--- a/eventsink/std.go
+++ b/eventsink/std.go
@@ -1,6 +1,10 @@
 package eventsink
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/sonde-go/events"
+)
 
 type Std struct{}
 
@@ -12,10 +16,10 @@ func (l *Std) Close() error {
 	return nil
 }
 
-func (l *Std) Write(fields map[string]interface{}, msg string) error {
+func (l *Std) Write(fields *events.Envelope) error {
 	fmt.Printf("%+v\n", fields)
-	if len(msg) > 0 {
-		fmt.Printf("\t%s\n", msg)
-	}
+	// if len(msg) > 0 {
+	// 	fmt.Printf("\t%s\n", msg)
+	// }
 	return nil
 }

--- a/eventsink/std.go
+++ b/eventsink/std.go
@@ -18,8 +18,5 @@ func (l *Std) Close() error {
 
 func (l *Std) Write(fields *events.Envelope) error {
 	fmt.Printf("%+v\n", fields)
-	// if len(msg) > 0 {
-	// 	fmt.Printf("\t%s\n", msg)
-	// }
 	return nil
 }

--- a/splunknozzle/nozzle.go
+++ b/splunknozzle/nozzle.go
@@ -78,7 +78,8 @@ func (s *SplunkFirehoseNozzle) AppCache(client cache.AppClient) (cache.Cache, er
 }
 
 // EventSink creates std sink or Splunk sink
-func (s *SplunkFirehoseNozzle) EventSink() (eventsink.Sink, error) {
+func (s *SplunkFirehoseNozzle) EventSink(cache cache.Cache) (eventsink.Sink, error) {
+
 	// EventWriter for writing events
 	writerConfig := &eventwriter.SplunkConfig{
 		Host:    s.config.SplunkHost,
@@ -119,7 +120,18 @@ func (s *SplunkFirehoseNozzle) EventSink() (eventsink.Sink, error) {
 		DropWarnThreshold:     s.config.DropWarnThreshold,
 	}
 
-	splunkSink := eventsink.NewSplunk(writers, sinkConfig)
+	LowerAddAppInfo := strings.ToLower(s.config.AddAppInfo)
+	parseConfig := &eventsink.ParseConfig{
+		SelectedEvents: s.config.WantedEvents,
+		AddAppName:     strings.Contains(LowerAddAppInfo, "appname"),
+		AddOrgName:     strings.Contains(LowerAddAppInfo, "orgname"),
+		AddOrgGuid:     strings.Contains(LowerAddAppInfo, "orgguid"),
+		AddSpaceName:   strings.Contains(LowerAddAppInfo, "spacename"),
+		AddSpaceGuid:   strings.Contains(LowerAddAppInfo, "spaceguid"),
+		AddTags:        s.config.AddTags,
+	}
+
+	splunkSink := eventsink.NewSplunk(writers, sinkConfig, parseConfig, cache)
 	splunkSink.Open()
 
 	s.logger.RegisterSink(splunkSink)
@@ -154,14 +166,6 @@ func (s *SplunkFirehoseNozzle) Nozzle(eventSource eventsource.Source, eventRoute
 // Run creates all necessary objects, reading events from CF firehose and sending to target Splunk index
 // It runs forever until something goes wrong
 func (s *SplunkFirehoseNozzle) Run(shutdownChan chan os.Signal) error {
-	eventSink, err := s.EventSink()
-	if err != nil {
-		s.logger.Error("Failed to create event sink", nil)
-		return err
-	}
-
-	s.logger.Info("Running splunk-firehose-nozzle with following configuration variables ", s.config.ToMap())
-
 	pcfClient, err := s.PCFClient()
 	if err != nil {
 		s.logger.Error("Failed to get info from CF Server", nil)
@@ -180,6 +184,14 @@ func (s *SplunkFirehoseNozzle) Run(shutdownChan chan os.Signal) error {
 		return err
 	}
 	defer appCache.Close()
+
+	eventSink, err := s.EventSink(appCache)
+	if err != nil {
+		s.logger.Error("Failed to create event sink", nil)
+		return err
+	}
+
+	s.logger.Info("Running splunk-firehose-nozzle with following configuration variables ", s.config.ToMap())
 
 	eventRouter, err := s.EventRouter(appCache, eventSink)
 	if err != nil {

--- a/splunknozzle/nozzle_test.go
+++ b/splunknozzle/nozzle_test.go
@@ -75,11 +75,12 @@ var _ = Describe("SplunkFirehoseNozzle", func() {
 	})
 
 	It("EventSink", func() {
-		_, err := noz.EventSink()
+		c := testing.NewMemoryCacheMock()
+		_, err := noz.EventSink(c)
 		Ω(err).ShouldNot(HaveOccurred())
 
 		config.Debug = true
-		_, err = noz.EventSink()
+		_, err = noz.EventSink(c)
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 

--- a/testing/event_sink_mock.go
+++ b/testing/event_sink_mock.go
@@ -1,17 +1,19 @@
 package testing
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/cloudfoundry/sonde-go/events"
+)
 
 type MemorySinkMock struct {
-	Events    []map[string]interface{}
-	Messages  []string
+	Events    []*events.Envelope
 	ReturnErr bool
 }
 
 func NewMemorySinkMock() *MemorySinkMock {
 	return &MemorySinkMock{
-		Events:   []map[string]interface{}{},
-		Messages: []string{},
+		Events: []*events.Envelope{},
 	}
 }
 
@@ -23,12 +25,12 @@ func (l *MemorySinkMock) Close() error {
 	return nil
 }
 
-func (l *MemorySinkMock) Write(fields map[string]interface{}, msg string) error {
+func (l *MemorySinkMock) Write(fields *events.Envelope) error {
 	if l.ReturnErr {
 		return errors.New("mockup error")
 	}
 
 	l.Events = append(l.Events, fields)
-	l.Messages = append(l.Messages, msg)
+	// l.Messages = append(l.Messages, msg)
 	return nil
 }

--- a/testing/event_sink_mock.go
+++ b/testing/event_sink_mock.go
@@ -31,6 +31,5 @@ func (l *MemorySinkMock) Write(fields *events.Envelope) error {
 	}
 
 	l.Events = append(l.Events, fields)
-	// l.Messages = append(l.Messages, msg)
 	return nil
 }


### PR DESCRIPTION
Changes to move event parsing logic to the worker threads from the main thread

This was done to address issue #285. The event dropping logic was already added previously to partially solve the back-pressure problem. But this change should completely solve the problem described in this issue.
Also, removed couple of irrelevant unit test cases after the change.