### PR TITLE
Nanoseconds in timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ DEST_KEY =_MetaData:Index
 REGEX = (sourcetype::cf:splunknozzle)
 FORMAT = new_index
 ```
+<p class="note"><strong>Note:</strong>Moving from version 1.2.4 to 1.2.5,timestamp will use nanosecond precision instead of milliseconds.</p>
+
 
 ## <a id='walkthrough'></a> Troubleshooting
 This topic describes how to troubleshoot Splunk Firehose Nozzle for Cloud Foundry.

--- a/eventsink/splunk.go
+++ b/eventsink/splunk.go
@@ -225,7 +225,7 @@ func (s *Splunk) buildEvent(fields map[string]interface{}) map[string]interface{
 
 	// Timestamp
 	if timestamp == "" {
-		timestamp = strconv.FormatInt(time.Now().Unix(), 10)
+		timestamp = utils.NanoSecondsToSeconds(time.Now().UnixNano())
 	}
 	event["time"] = timestamp
 

--- a/eventsink/splunk_test.go
+++ b/eventsink/splunk_test.go
@@ -277,7 +277,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses current time without event timestamp", func() {
-			eventTime, err := strconv.Atoi(event["time"].(string))
+			eventTime, err := strconv.ParseFloat(event["time"].(string), 64)
 
 			Expect(err).To(BeNil())
 			Expect(time.Now().Unix()).To(BeNumerically("~", eventTime, 2))
@@ -340,7 +340,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses event timestamp", func() {
-			eventTimeSeconds := "1467128185.055"
+			eventTimeSeconds := "1467128185.055072010"
 			Expect(event["time"]).To(Equal(eventTimeSeconds))
 		})
 
@@ -393,7 +393,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses current time without event timestamp", func() {
-			eventTime, err := strconv.Atoi(event["time"].(string))
+			eventTime, err := strconv.ParseFloat(event["time"].(string), 64)
 
 			Expect(err).To(BeNil())
 			Expect(time.Now().Unix()).To(BeNumerically("~", eventTime, 2))
@@ -448,7 +448,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses current time without event timestamp", func() {
-			eventTime, err := strconv.Atoi(event["time"].(string))
+			eventTime, err := strconv.ParseFloat(event["time"].(string), 64)
 
 			Expect(err).To(BeNil())
 			Expect(time.Now().Unix()).To(BeNumerically("~", eventTime, 2))
@@ -503,7 +503,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses current time without event timestamp", func() {
-			eventTime, err := strconv.Atoi(event["time"].(string))
+			eventTime, err := strconv.ParseFloat(event["time"].(string), 64)
 
 			Expect(err).To(BeNil())
 			Expect(time.Now().Unix()).To(BeNumerically("~", eventTime, 2))
@@ -563,7 +563,7 @@ var _ = Describe("Splunk", func() {
 		})
 
 		It("uses current time without event timestamp", func() {
-			eventTime, err := strconv.Atoi(event["time"].(string))
+			eventTime, err := strconv.ParseFloat(event["time"].(string), 64)
 
 			Expect(err).To(BeNil())
 			Expect(time.Now().Unix()).To(BeNumerically("~", eventTime, 2))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -61,7 +61,7 @@ func GetHostIPInfo(host string) (string, string, error) {
 
 func NanoSecondsToSeconds(nanoseconds int64) string {
 	seconds := float64(nanoseconds) * math.Pow(1000, -3)
-	return fmt.Sprintf("%.3f", seconds)
+	return fmt.Sprintf("%.9f", seconds)
 }
 
 // ToJSON tries to detect the JSON pattern for msg first, if msg contains JSON pattern either

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cloudfoundry/sonde-go/events"
@@ -60,8 +60,15 @@ func GetHostIPInfo(host string) (string, string, error) {
 }
 
 func NanoSecondsToSeconds(nanoseconds int64) string {
-	seconds := float64(nanoseconds) * math.Pow(1000, -3)
-	return fmt.Sprintf("%.9f", seconds)
+	nanoStr := strconv.FormatInt(nanoseconds, 10)
+
+	//if received < 1 seconds
+	if len(nanoStr) < 10 {
+		return "0.0"
+	}
+
+	decimalIndex := len(nanoStr) - 9
+	return fmt.Sprintf("%s.%s", nanoStr[:decimalIndex], nanoStr[decimalIndex:])
 }
 
 // ToJSON tries to detect the JSON pattern for msg first, if msg contains JSON pattern either

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -94,6 +94,6 @@ var _ = Describe("Testing Utils packages", func() {
 
 	It("NanoSecondsToSeconds", func() {
 		nano := NanoSecondsToSeconds(1501981978112315664)
-		Expect(nano).To(Equal("1501981978.112"))
+		Expect(nano).To(Equal("1501981978.112315664"))
 	})
 })


### PR DESCRIPTION
This is to fix an issue, where events with micro/nano second timestamps were not sorted properly due to timestamps getting truncated up to milliseconds.