### PR TITLE
Fix event-type filtration bug

### DIFF
--- a/eventrouter/default.go
+++ b/eventrouter/default.go
@@ -32,6 +32,10 @@ func New(appCache cache.Cache, sink eventsink.Sink, config *Config) (Router, err
 }
 
 func (r *router) Route(msg *events.Envelope) error {
+	if _, ok := r.selectedEvents[eventType.String()]; !ok {
+		// Ignore this event since we are not interested
+		return nil
+	}
 	_ = r.sink.Write(msg)
 
 	return nil

--- a/eventrouter/default.go
+++ b/eventrouter/default.go
@@ -32,10 +32,13 @@ func New(appCache cache.Cache, sink eventsink.Sink, config *Config) (Router, err
 }
 
 func (r *router) Route(msg *events.Envelope) error {
+	eventType := msg.GetEventType()
+
 	if _, ok := r.selectedEvents[eventType.String()]; !ok {
 		// Ignore this event since we are not interested
 		return nil
 	}
+	
 	_ = r.sink.Write(msg)
 
 	return nil


### PR DESCRIPTION
While moving routing logic(#313) to Splunk sink writer, one bug was introduced. Due to that, the `events` config wasn't working as expected. 
This PR will fix that issue.