### PR TITLE
Fix race conditions and fix some unit test cases

### DIFF
--- a/eventwriter/splunk_test.go
+++ b/eventwriter/splunk_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Splunk", func() {
 
 		It("doesn't change index as it's already set", func() {
 			config.Index = "index_cf"
-			client := NewSplunk(config)
+			client := NewSplunkEvent(config)
 			event1 := map[string]interface{}{"event": map[string]interface{}{
 				"greeting": "hello world",
 			}}

--- a/monitoring/metric_test.go
+++ b/monitoring/metric_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Monitoring", func() {
 		go monitor.Start()
 		time.Sleep(3 * time.Second)
 		monitor.Stop()
-		value := writer.CapturedEvents[len(writer.CapturedEvents)-1]["fields"].(map[string]interface{})["metric_name:b"]
+		value := writer.Read()[len(writer.CapturedEvents)-1]["fields"].(map[string]interface{})["metric_name:b"]
 		Expect(value).To(Equal(uint64(10)))
 		Expect(len(writer.CapturedEvents)).To(Equal(1))
 	})
@@ -53,7 +53,7 @@ var _ = Describe("Monitoring", func() {
 		go monitor.Start()
 		time.Sleep(3 * time.Second)
 		monitor.Stop()
-		value := writer.CapturedEvents[len(writer.CapturedEvents)-1]["fields"].(map[string]interface{})["metric_name:b"]
+		value := writer.Read()[len(writer.CapturedEvents)-1]["fields"].(map[string]interface{})["metric_name:b"]
 		Expect(value).To(Equal(uint64(20)))
 	})
 

--- a/testing/event_writer_metric_mock.go
+++ b/testing/event_writer_metric_mock.go
@@ -7,7 +7,7 @@ import (
 )
 
 type EventWriterMetricMock struct {
-	lock           sync.Mutex
+	lock           sync.RWMutex
 	Block          bool
 	CapturedEvents []map[string]interface{}
 	PostBatchFn    func(events []map[string]interface{}) error
@@ -30,4 +30,10 @@ func (m *EventWriterMetricMock) Write(events []map[string]interface{}) (error, u
 		m.lock.Unlock()
 	}
 	return nil, uint64(len(events))
+}
+
+func (m *EventWriterMetricMock) Read() []map[string]interface{} {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.CapturedEvents
 }

--- a/testing/integration/testcases/test_nozzle_configurations.py
+++ b/testing/integration/testcases/test_nozzle_configurations.py
@@ -153,4 +153,4 @@ class TestSplunkNozzle():
             start_time="-15m@m",type="results")
         assert len(search_results) > 0
         listofMetrics =  search_results[0]['values(metric_name)']
-        assert  set(listofMetrics) == set(['firehose.events.dropped.count', 'firehose.events.received.count', 'nozzle.cache.boltdb.hit',  'nozzle.cache.memory.hit', 'nozzle.cache.remote.hit', 'nozzle.queue.percentage', 'splunk.events.dropped.count', 'splunk.events.sent.count', 'splunk.events.throughput'])
+        assert  set(listofMetrics) == set({'nozzle.cache.memory.miss', 'firehose.events.received.count', 'nozzle.cache.boltdb.hit', 'splunk.events.sent.count', 'nozzle.usage.ram', 'nozzle.cache.remote.hit', 'splunk.events.throughput', 'nozzle.cache.boltdb.miss', 'nozzle.cache.remote.miss', 'splunk.events.dropped.count', 'nozzle.usage.cpu', 'nozzle.queue.percentage', 'firehose.events.dropped.count', 'nozzle.cache.memory.hit'})


### PR DESCRIPTION
Race conditions detected with `race` flag enabled.

- The ticker field is initialised in a goroutine and stopped in main thread. Add a mutex to access this field
