### PR TITLE
Add metric index to main.yml

### DIFF
--- a/.github/update_manifest.sh
+++ b/.github/update_manifest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 #Set below params in github env variable settings
-# API_ENDPOINT, API_USER, API_PASSWORD, SPLUNK_TOKEN, SPLUNK_HOST, SPLUNK_INDEX
+# API_ENDPOINT, API_USER, API_PASSWORD, SPLUNK_TOKEN, SPLUNK_HOST, SPLUNK_INDEX, SPLUNK_METRIC_INDEX
 #Update manifest for deployment
 sed -i 's@API_ENDPOINT:.*@'"API_ENDPOINT: $API_ENDPOINT"'@' .github/workflows/ci_nozzle_manifest.yml
 sed -i 's@API_USER:.*@'"API_USER: $API_USER"'@' .github/workflows/ci_nozzle_manifest.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
       SPLUNK_INDEX: ${{ secrets.SPLUNK_INDEX  }}
       SPLUNK_TOKEN: ${{ secrets.SPLUNK_TOKEN  }}
       SPLUNK_HOST: ${{ secrets.SPLUNK_HOST  }}
+      SPLUNK_METRIC_INDEX: ${{ secrets.SPLUNK_METRIC_INDEX  }}
 
     needs: build
     runs-on: ubuntu-latest
@@ -150,6 +151,7 @@ jobs:
       SPLUNK_INDEX: ${{ secrets.SPLUNK_INDEX  }}
       SPLUNK_TOKEN: ${{ secrets.SPLUNK_TOKEN  }}
       SPLUNK_HOST: ${{ secrets.SPLUNK_HOST  }}
+      SPLUNK_METRIC_INDEX: ${{ secrets.SPLUNK_METRIC_INDEX  }}
 
 
     needs: deploy_nozzle


### PR DESCRIPTION
While pushing the nozzle to cf, we're using $SPLUNK_METRIC_INDEX env variable, but we're not setting that variable in the first place. So there's a test case failing 