### PR TITLE
fix: add vendor to semgrepignore

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,3 +1,26 @@
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+.yarn/
+
+# Common test paths
+test/
+tests/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+
 tile/build.sh 
 .github/pre-req.sh
 testing/


### PR DESCRIPTION
We don't need to check for vendor/* for semgrep, 
those are libraries.